### PR TITLE
feat: Epic 4 — Subscription domain state machine

### DIFF
--- a/app/db/repositories.py
+++ b/app/db/repositories.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 
 from app.db.models import Payment, Subscription, SubscriptionStatus, User
 from app.db.session import get_session
+from app.domain.subscription import transition
 
 
 def _utcnow() -> datetime:
@@ -78,7 +79,7 @@ class SubscriptionRepository:
             subscription = await session.get(Subscription, subscription_id)
             if subscription is None:
                 raise ValueError(f"Subscription {subscription_id} not found")
-            subscription.status = new_status
+            transition(subscription, new_status)
             await session.commit()
             await session.refresh(subscription)
             return subscription

--- a/app/db/repositories.py
+++ b/app/db/repositories.py
@@ -37,6 +37,11 @@ class UserRepository:
             return user
         return await UserRepository.create(telegram_id)
 
+    @staticmethod
+    async def get_by_id(user_id: int) -> User | None:
+        async with get_session() as session:
+            return await session.get(User, user_id)
+
 
 class SubscriptionRepository:
     @staticmethod
@@ -71,7 +76,9 @@ class SubscriptionRepository:
 
     @staticmethod
     async def update_status(
-        subscription_id: int, new_status: SubscriptionStatus | str
+        subscription_id: int,
+        new_status: SubscriptionStatus | str,
+        expires_at: datetime | None = None,
     ) -> Subscription:
         if isinstance(new_status, str):
             new_status = SubscriptionStatus(new_status)
@@ -80,6 +87,8 @@ class SubscriptionRepository:
             if subscription is None:
                 raise ValueError(f"Subscription {subscription_id} not found")
             transition(subscription, new_status)
+            if expires_at is not None:
+                subscription.expires_at = expires_at
             await session.commit()
             await session.refresh(subscription)
             return subscription

--- a/app/domain/pricing.py
+++ b/app/domain/pricing.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+# hotfix: temporary September pricing, Epic 5 will replace with real pricing service
+_PRICE_CUTOFF = datetime(2026, 10, 1)
+_PRICE_BEFORE_CUTOFF = 45
+_PRICE_AFTER_CUTOFF = 55
+
+
+def get_current_price() -> int:
+    return _PRICE_BEFORE_CUTOFF if datetime.now() < _PRICE_CUTOFF else _PRICE_AFTER_CUTOFF

--- a/app/domain/subscription.py
+++ b/app/domain/subscription.py
@@ -1,0 +1,41 @@
+# Reuses the DB layer's SubscriptionStatus enum directly (same values,
+# nothing to keep in sync) — this module still has zero aiogram imports
+# and zero direct DB session handling; it only operates on an
+# already-loaded Subscription object, the caller persists any change.
+from app.db.models import Subscription, SubscriptionStatus
+
+TRANSITIONS: dict[SubscriptionStatus, frozenset[SubscriptionStatus]] = {
+    SubscriptionStatus.PENDING: frozenset({SubscriptionStatus.ACTIVE}),
+    SubscriptionStatus.ACTIVE: frozenset(
+        {SubscriptionStatus.EXPIRING, SubscriptionStatus.ACTIVE}
+    ),
+    SubscriptionStatus.EXPIRING: frozenset(
+        {SubscriptionStatus.ACTIVE, SubscriptionStatus.EXPIRED}
+    ),
+    SubscriptionStatus.EXPIRED: frozenset(
+        {SubscriptionStatus.ACTIVE, SubscriptionStatus.KICKED}
+    ),
+    SubscriptionStatus.KICKED: frozenset({SubscriptionStatus.ACTIVE}),
+}
+
+
+class InvalidTransitionError(Exception):
+    def __init__(
+        self, from_status: SubscriptionStatus, to_status: SubscriptionStatus
+    ) -> None:
+        self.from_status = from_status
+        self.to_status = to_status
+        super().__init__(
+            f"Cannot transition subscription from {from_status.value} to {to_status.value}"
+        )
+
+
+def can_transition(from_status: SubscriptionStatus, to_status: SubscriptionStatus) -> bool:
+    return to_status in TRANSITIONS.get(from_status, frozenset())
+
+
+def transition(subscription: Subscription, to_status: SubscriptionStatus) -> Subscription:
+    if not can_transition(subscription.status, to_status):
+        raise InvalidTransitionError(subscription.status, to_status)
+    subscription.status = to_status
+    return subscription

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from aiogram import F, Router
 from aiogram.types import Message, CallbackQuery
 from aiogram.filters import CommandStart, Command
@@ -6,6 +8,7 @@ from aiogram.fsm.context import FSMContext
 
 import app.keyboards as kb
 from app.config import settings
+from app.db.repositories import PaymentRepository, SubscriptionRepository, UserRepository
 from app.domain.pricing import get_current_price
 
 router = Router()
@@ -126,31 +129,43 @@ async def request_screenshot(callback: CallbackQuery, state: FSMContext):
 async def receive_screenshot(message: Message, state: FSMContext):
     """Получить скриншот от пользователя"""
     user = message.from_user
-    
+
+    db_user = await UserRepository.get_or_create(user.id)
+    subscription = await SubscriptionRepository.create(
+        user_id=db_user.id, expires_at=None
+    )
+    await PaymentRepository.create(
+        subscription_id=subscription.id,
+        provider="manual",
+        provider_ref=f"manual-{message.message_id}",
+        amount=Decimal(get_current_price()),
+        currency="PLN",
+    )
+
     caption = (
         f"💳 Новая оплата!\n\n"
         f"👤 От: {user.full_name}\n"
         f"🆔 ID: {user.id}\n"
         f"📱 Username: @{user.username if user.username else 'не указан'}"
     )
-    
 
     try:
         await message.bot.send_photo(
             chat_id=ADMIN_ID,
             photo=message.photo[-1].file_id,
-            caption=caption
+            caption=caption,
+            reply_markup=kb.get_confirm_payment_keyboard(subscription.id)
         )
     except Exception as e:
         print(f"Ошибка отправки админу: {e}")
-    
-   
+
+
     await message.answer(
         text="✅ Спасибо! Твой скриншот отправлен Ирине.\n\n"
              "Доступ будет активирован в течение дня. Я пришлю тебе уведомление! 💫",
         reply_markup=kb.main_menu
     )
-    
+
     await state.clear()
 
 

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from aiogram import F, Router
 from aiogram.types import Message, CallbackQuery
 from aiogram.filters import CommandStart, Command
@@ -8,6 +6,7 @@ from aiogram.fsm.context import FSMContext
 
 import app.keyboards as kb
 from app.config import settings
+from app.domain.pricing import get_current_price
 
 router = Router()
 
@@ -88,8 +87,7 @@ async def show_examples(callback: CallbackQuery):
 @router.callback_query(F.data == 'payment')
 async def show_payment(callback: CallbackQuery):
     """Показать информацию об оплате"""
-    # hotfix: temporary September pricing, Epic 5 will replace with real pricing service
-    price = 45 if datetime.now() < datetime(2026, 10, 1) else 55
+    price = get_current_price()
     text = (
         f"💳 Стоимость участия в закрытом клубе: {price} zł\n\n"
         "После оплаты ты автоматически получаешь доступ в закрытый Telegram-канал.\n\n"

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 from aiogram import F, Router
@@ -8,8 +9,10 @@ from aiogram.fsm.context import FSMContext
 
 import app.keyboards as kb
 from app.config import settings
+from app.db.models import SubscriptionStatus
 from app.db.repositories import PaymentRepository, SubscriptionRepository, UserRepository
 from app.domain.pricing import get_current_price
+from app.domain.subscription import InvalidTransitionError
 
 router = Router()
 
@@ -167,6 +170,42 @@ async def receive_screenshot(message: Message, state: FSMContext):
     )
 
     await state.clear()
+
+
+@router.callback_query(F.data.startswith('confirm_payment:'))
+async def confirm_payment(callback: CallbackQuery):
+    """Админ подтверждает оплату и активирует подписку"""
+    if callback.from_user.id != ADMIN_ID:
+        await callback.answer()
+        return
+
+    subscription_id = int(callback.data.split(':', 1)[1])
+    expires_at = datetime.now() + timedelta(days=30)
+
+    try:
+        subscription = await SubscriptionRepository.update_status(
+            subscription_id, SubscriptionStatus.ACTIVE, expires_at=expires_at
+        )
+    except InvalidTransitionError:
+        await callback.answer("Эта оплата уже обработана.", show_alert=True)
+        return
+
+    subscriber = await UserRepository.get_by_id(subscription.user_id)
+    if subscriber is not None:
+        try:
+            await callback.bot.send_message(
+                chat_id=subscriber.telegram_id,
+                text="🎉 Твоя оплата подтверждена! Доступ в закрытый клуб активен 30 дней.\n\n"
+                     "Ирина добавит тебя в канал в течение дня 💫"
+            )
+        except Exception as e:
+            print(f"Ошибка отправки подтверждения пользователю: {e}")
+
+    await callback.message.edit_caption(
+        caption=(callback.message.caption or "") + "\n\n✅ Оплата подтверждена",
+        reply_markup=None
+    )
+    await callback.answer("Подписка активирована")
 
 
 @router.message(ScreenshotState.waiting_for_screenshot)

--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -1,7 +1,7 @@
-from datetime import datetime
-
 from aiogram.types import (ReplyKeyboardMarkup, KeyboardButton,
                            InlineKeyboardMarkup, InlineKeyboardButton)
+
+from app.domain.pricing import get_current_price
 
 # ========== ОБЫЧНЫЕ КЛАВИАТУРЫ (если нужны) ==========
 
@@ -34,8 +34,7 @@ inside_menu = InlineKeyboardMarkup(inline_keyboard=[
 
 # Меню раздела "Оплата"
 def get_payment_menu() -> InlineKeyboardMarkup:
-    # hotfix: temporary September pricing, Epic 5 will replace with real pricing service
-    price = 45 if datetime.now() < datetime(2026, 10, 1) else 55
+    price = get_current_price()
     return InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(
             text=f'💸 Оплатить {price} zł',

--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -44,6 +44,15 @@ def get_payment_menu() -> InlineKeyboardMarkup:
         [InlineKeyboardButton(text='↩️ Назад в меню', callback_data='main_menu')]
     ])
 
+# Кнопка подтверждения оплаты (для админа)
+def get_confirm_payment_keyboard(subscription_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(
+            text='✅ Confirm payment',
+            callback_data=f'confirm_payment:{subscription_id}'
+        )]
+    ])
+
 # Простая кнопка "Назад"
 back_menu = InlineKeyboardMarkup(inline_keyboard=[
     [InlineKeyboardButton(text='↩️ Назад в меню', callback_data='main_menu')]


### PR DESCRIPTION
## What
Formalizes subscription lifecycle transitions (PENDING → ACTIVE → EXPIRING 
→ EXPIRED → KICKED) as an explicit, validated domain module, and wires the 
existing manual screenshot-payment flow through it — Irina still confirms 
payments manually, but confirmations now update real DB state instead of 
disappearing into a Telegram message.

## Closes
Closes #14, Closes #15

## Self-verification
- Full pending → admin-confirm → active flow tested against real Postgres, 
  including expires_at (~30 days) and subscriber notification
- Non-admin telegram_id clicking confirm correctly ignored (no state change)
- Illegal transition (PENDING → EXPIRED) correctly raises 
  InvalidTransitionError, verified at both domain and repository level

## Notes
- Found and fixed pre-existing price-lookup duplication (from the 
  September pricing hotfix) while wiring the payment flow — extracted to 
  app/domain/pricing.get_current_price(), now used in one place instead 
  of two
- Domain module reuses SubscriptionStatus from app.db.models rather than 
  a parallel enum — same values, avoids drift, still zero aiogram/DB coupling