### PR TITLE
feat: Epic 5 (part 1) — Stripe Checkout with card + BLIK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 BOT_TOKEN=your_bot_token_here
+BOT_USERNAME=your_bot_username_here
 ADMIN_ID=your_admin_id_here
 
 # Optional: set to override the constructed connection string entirely

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     bot_token: str
+    bot_username: str  # no leading @, used to build https://t.me/<bot_username> deep links
     admin_id: int
     database_url: str | None = None  # built from db_* fields below if not set directly
     stripe_secret_key: str | None = None  # stub for Epic 5, not used yet

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 from decimal import Decimal
 
@@ -13,6 +14,7 @@ from app.db.models import SubscriptionStatus
 from app.db.repositories import PaymentRepository, SubscriptionRepository, UserRepository
 from app.domain.pricing import get_current_price
 from app.domain.subscription import InvalidTransitionError
+from app.services.stripe_service import create_checkout_session
 
 router = Router()
 
@@ -101,6 +103,18 @@ async def show_payment(callback: CallbackQuery):
         "✨ После оплаты отправь скрин в этот чат, и я активирую доступ вручную в течение дня."
     )
     await callback.message.edit_text(text, reply_markup=kb.get_payment_menu())
+    await callback.answer()
+
+
+@router.callback_query(F.data == 'stripe_checkout')
+async def stripe_checkout(callback: CallbackQuery):
+    """Создать Stripe Checkout Session и отправить пользователю ссылку на оплату"""
+    checkout_url = await asyncio.to_thread(create_checkout_session, callback.from_user.id)
+    text = (
+        "💳 Ссылка на оплату готова — доступны карта и BLIK.\n\n"
+        "После оплаты Ирина активирует твой доступ в течение дня 💫"
+    )
+    await callback.message.answer(text, reply_markup=kb.get_stripe_checkout_keyboard(checkout_url))
     await callback.answer()
 
 

--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -37,10 +37,17 @@ def get_payment_menu() -> InlineKeyboardMarkup:
     price = get_current_price()
     return InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(
-            text=f'💸 Оплатить {price} zł',
-            url=f'https://buy.stripe.com/твоя-ссылка-{price}zl'
+            text=f'💳 Оплатить картой / BLIK ({price} zł)',
+            callback_data='stripe_checkout'
         )],
         [InlineKeyboardButton(text='📩 Отправить скрин оплаты', callback_data='send_screenshot')],
+        [InlineKeyboardButton(text='↩️ Назад в меню', callback_data='main_menu')]
+    ])
+
+# Кнопка со ссылкой на готовую Stripe Checkout Session
+def get_stripe_checkout_keyboard(checkout_url: str) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text='💳 Перейти к оплате', url=checkout_url)],
         [InlineKeyboardButton(text='↩️ Назад в меню', callback_data='main_menu')]
     ])
 

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -1,0 +1,34 @@
+import stripe
+
+from app.config import settings
+from app.domain.pricing import get_current_price
+
+stripe.api_key = settings.stripe_secret_key
+
+
+def create_checkout_session(telegram_id: int) -> str:
+    """Create a one-time Stripe Checkout Session for the current subscription
+    price and return its hosted URL. Does not touch the database — the
+    webhook (next sprint) reads client_reference_id to identify the payer."""
+    price_grosze = get_current_price() * 100
+
+    session = stripe.checkout.Session.create(
+        payment_method_types=["card", "blik"],
+        mode="payment",
+        line_items=[
+            {
+                "price_data": {
+                    "currency": "pln",
+                    "unit_amount": price_grosze,
+                    "product_data": {
+                        "name": "DressCode by Irina — monthly access",
+                    },
+                },
+                "quantity": 1,
+            }
+        ],
+        client_reference_id=str(telegram_id),
+        success_url=f"https://t.me/{settings.bot_username}?start=payment_success",
+        cancel_url=f"https://t.me/{settings.bot_username}?start=payment_cancelled",
+    )
+    return session.url

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pydantic-settings==2.15.0
 sqlalchemy[asyncio]==2.0.52
 alembic==1.19.1
 asyncpg==0.31.0
+stripe==15.6.1
 


### PR DESCRIPTION
## What
Adds an automated Stripe Checkout option (card + BLIK) alongside the 
existing manual screenshot-payment flow. This is Checkout Session 
creation only — payment confirmation, DB persistence, and idempotency 
are handled by the webhook in the next sprint (Issue #17/18).

## Closes
Closes #16

## Self-verification
- Checkout Session verified directly via Stripe API: payment_method_types 
  = [card, blik], amount matches get_current_price() exactly (45 zł), 
  currency=PLN, mode=payment (one-time, not recurring), 
  client_reference_id correctly carries the Telegram user id
- Manually completed a full test-card payment through the hosted Checkout 
  page — confirmed successful charge in Stripe test dashboard
- Removed a dead hardcoded buy.stripe.com placeholder link left over from 
  before this project's automation work began
- Confirmed via code read-through that the existing manual 
  screenshot-payment flow (send_screenshot/receive_screenshot/
  confirm_payment) is untouched by this change

## Notes
- BLIK's full redirect-based confirmation flow can't be meaningfully 
  tested end-to-end until the webhook exists (next sprint) — this sprint 
  only confirms it's offered as a valid payment method on the Checkout page